### PR TITLE
Example failing spec when html is mounted

### DIFF
--- a/src/lib/create-instance.js
+++ b/src/lib/create-instance.js
@@ -18,7 +18,7 @@ export default function createConstructor (
   component: Component,
   options: Options
 ): Component {
-  const mountingOptions = extractOptions(options)
+  const mountingOptions = extractOptions(component, options)
 
   const vue = mountingOptions.localVue || createLocalVue()
 

--- a/src/options/extract-options.js
+++ b/src/options/extract-options.js
@@ -1,5 +1,6 @@
 // @flow
 import config from '../config'
+import pickBy from 'lodash/pickBy'
 
 function getStubs (optionStubs) {
   if (optionStubs || Object.keys(config.stubs).length > 0) {
@@ -14,7 +15,18 @@ function getStubs (optionStubs) {
   }
 }
 
+function getPropsNotOnComponent(componentProps = [], propsData = {}) {
+  return pickBy(propsData, (_value, key) => componentProps.indexOf(key) === -1)
+}
+
+function getAttrs ({ props: componentProps }, { propsData, attrs }) {
+  const nonPropAttrs = getPropsNotOnComponent(componentProps, propsData);
+
+  return Object.assign(attrs, nonPropAttrs)
+}
+
 export default function extractOptions (
+  component: Component,
   options: Options
 ): Options {
   return {
@@ -22,7 +34,7 @@ export default function extractOptions (
     context: options.context,
     provide: options.provide,
     stubs: getStubs(options.stubs),
-    attrs: options.attrs,
+    attrs: getAttrs(component, options),
     listeners: options.listeners,
     slots: options.slots,
     localVue: options.localVue

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -148,4 +148,14 @@ describe('mount', () => {
     const fn = () => mount(TestComponent)
     expect(fn).to.throw()
   })
+
+  describe.only('new', () => {
+    it('applies inheritAttrs', () => {
+      const wrapper = mount(ComponentWithProps, { attachToDocument:true, propsData: { prop1: 'prop1', extra: 'attr' }, attrs: { height: '50px' } })
+
+      expect(wrapper.vm).to.be.an('object')
+      expect(wrapper.vm.$attrs).to.eql({ height: "50px", extra: "attr" });
+      expect(wrapper.html()).to.equal(`<div extra="attrs" height="50px"><p class="prop-1">prop1</p> <p class="prop-2"></p></div>`)
+    })
+  })
 })


### PR DESCRIPTION
So i noticed that the HTML on the base element when we are rendering does not match how i *think* Vue handles rendering of attrs/props data

In the mount spec that I add here, the $attrs are correct but the rendered html does not have the attributes rendered on the root element.

Example of how vue handles this: http://jsfiddle.net/Austio/w0jdxs6y/2/

```
// Karma Output from the spec
✗ applies inheritAttrs
  AssertionError: expected '<div><p class="prop-1">prop1</p> <p class="prop-2"></p></div>' to equal '<div extra="attrs" height="50px"><p class="prop-1">prop1</p> <p class="prop-2"></p></div>'

Formatted
expected
'<div><p class="prop-1">prop1</p> <p class="prop-2"></p></div>' 
to equal
'<div extra="attrs" height="50px"><p class="prop-1">prop1</p> <p class="prop-2"></p></div>'
```